### PR TITLE
Remove extraneous http in legalpage

### DIFF
--- a/legalpage.tex
+++ b/legalpage.tex
@@ -19,7 +19,7 @@ The latest version of this book is available (without charge) in portable docume
 \rule{0pt}{0pt} \hspace{1in} \verb+http://www.southernct.edu/~fields/+.  
 
 \noindent The pdf and the source code repository can also be found on GitHub at \newline
-\rule{0pt}{0pt} \hspace{1in} \verb+http://http://osj1961.github.io/giam/+.  
+\rule{0pt}{0pt} \hspace{1in} \verb+http://osj1961.github.io/giam/+.  
 
 
 \end{quote}


### PR DESCRIPTION
Maybe it could also use [hyperlinks](https://www.overleaf.com/learn/latex/Hyperlinks#Linking_web_addresses) instead?